### PR TITLE
Change for region specific variants

### DIFF
--- a/src/classes/PMHR_NextFormController.cls
+++ b/src/classes/PMHR_NextFormController.cls
@@ -16,7 +16,7 @@ public class PMHR_NextFormController {
         try {
             Pokemon__c pokemon = [SELECT Form__c FROM Pokemon__c WHERE Id = :pokemonId LIMIT 1];
             pokemon.Form__c = nextFormId;
-            pokemon.Variant__c = variant;
+            pokemon.Region_Specific_Variant__c = variant;
             update pokemon;
         } catch (DmlException ex) {
             System.debug(ex.getDmlMessage(0));
@@ -69,7 +69,6 @@ public class PMHR_NextFormController {
             this.id = pokemonForm.Id;
             this.name = pokemonForm.Name;
             this.pokedexNumber = pokemonForm.Pokedex_Number__c;
-            this.variant = PMHR_Utilities.REGION_VARIANT_STANDARD;
             this.familyStage = pokemonForm.Family_Stage__c;
         }
 

--- a/src/classes/PMHR_NextFormController_Test.cls
+++ b/src/classes/PMHR_NextFormController_Test.cls
@@ -101,7 +101,7 @@ private class PMHR_NextFormController_Test {
 
     static testMethod void shouldSetNextPokemonForm() {
         //given
-        List<Pokemon__c> pokemons = [SELECT Id, Form__r.Family_Stage__c, Variant__c FROM Pokemon__c WHERE Form__r.Family__c = :FAMILY_ONE AND Form__r.Family_Stage__c < 3];
+        List<Pokemon__c> pokemons = [SELECT Id, Form__r.Family_Stage__c, Region_Specific_Variant__c FROM Pokemon__c WHERE Form__r.Family__c = :FAMILY_ONE AND Form__r.Family_Stage__c < 3];
 
         Pokemon__c firstStagePokemon;
         Pokemon__c secondStagePokemon;
@@ -116,7 +116,7 @@ private class PMHR_NextFormController_Test {
 
         //when
         Test.startTest();
-        PMHR_NextFormController.setPokemonForm(firstStagePokemon.Id, secondStagePokemon.Form__c, secondStagePokemon.Variant__c);
+        PMHR_NextFormController.setPokemonForm(firstStagePokemon.Id, secondStagePokemon.Form__c, secondStagePokemon.Region_Specific_Variant__c);
         Test.stopTest();
 
         //then
@@ -126,12 +126,12 @@ private class PMHR_NextFormController_Test {
 
     static testMethod void shouldNotSetNextPokemonForm_formFamilyDifferent() {
         //given
-        Pokemon__c firstStagePokemon = [SELECT Id, Form__r.Family_Stage__c, Variant__c FROM Pokemon__c WHERE Form__r.Family__c = :FAMILY_TWO LIMIT 1];
-        Pokemon__c secondStagePokemon = [SELECT Id, Form__r.Family_Stage__c, Variant__c FROM Pokemon__c WHERE Form__r.Family__c = :FAMILY_ONE AND Form__r.Family_Stage__c = 2 LIMIT 1];
+        Pokemon__c firstStagePokemon = [SELECT Id, Form__r.Family_Stage__c, Region_Specific_Variant__c FROM Pokemon__c WHERE Form__r.Family__c = :FAMILY_TWO LIMIT 1];
+        Pokemon__c secondStagePokemon = [SELECT Id, Form__r.Family_Stage__c, Region_Specific_Variant__c FROM Pokemon__c WHERE Form__r.Family__c = :FAMILY_ONE AND Form__r.Family_Stage__c = 2 LIMIT 1];
 
         //when
         Test.startTest();
-        PMHR_NextFormController.setPokemonForm(firstStagePokemon.Id, secondStagePokemon.Form__c, secondStagePokemon.Variant__c);
+        PMHR_NextFormController.setPokemonForm(firstStagePokemon.Id, secondStagePokemon.Form__c, secondStagePokemon.Region_Specific_Variant__c);
         Test.stopTest();
 
         //then
@@ -141,7 +141,7 @@ private class PMHR_NextFormController_Test {
 
     static testMethod void shouldNotSetNextPokemonForm_formStageLower() {
         //given
-        List<Pokemon__c> pokemons = [SELECT Id, Form__r.Family_Stage__c, Variant__c FROM Pokemon__c WHERE Form__r.Family__c = :FAMILY_ONE AND Form__r.Family_Stage__c < 3];
+        List<Pokemon__c> pokemons = [SELECT Id, Form__r.Family_Stage__c, Region_Specific_Variant__c FROM Pokemon__c WHERE Form__r.Family__c = :FAMILY_ONE AND Form__r.Family_Stage__c < 3];
 
         Pokemon__c firstStagePokemon;
         Pokemon__c secondStagePokemon;
@@ -156,7 +156,7 @@ private class PMHR_NextFormController_Test {
 
         //when
         Test.startTest();
-        PMHR_NextFormController.setPokemonForm(secondStagePokemon.Id, firstStagePokemon.Form__c, firstStagePokemon.Variant__c);
+        PMHR_NextFormController.setPokemonForm(secondStagePokemon.Id, firstStagePokemon.Form__c, firstStagePokemon.Region_Specific_Variant__c);
         Test.stopTest();
 
         //then
@@ -166,7 +166,7 @@ private class PMHR_NextFormController_Test {
 
     static testMethod void shouldNotSetNextPokemonForm_noPokemons() {
         //given
-        List<Pokemon__c> pokemons = [SELECT Id, Form__r.Family_Stage__c, Variant__c FROM Pokemon__c WHERE Form__r.Family__c = :FAMILY_ONE AND Form__r.Family_Stage__c < 3];
+        List<Pokemon__c> pokemons = [SELECT Id, Form__r.Family_Stage__c, Region_Specific_Variant__c FROM Pokemon__c WHERE Form__r.Family__c = :FAMILY_ONE AND Form__r.Family_Stage__c < 3];
 
         Pokemon__c firstStagePokemon;
         Pokemon__c secondStagePokemon;
@@ -182,7 +182,7 @@ private class PMHR_NextFormController_Test {
 
         //when
         Test.startTest();
-        PMHR_NextFormController.setPokemonForm(firstStagePokemon.Id, secondStagePokemon.Form__c, secondStagePokemon.Variant__c);
+        PMHR_NextFormController.setPokemonForm(firstStagePokemon.Id, secondStagePokemon.Form__c, secondStagePokemon.Region_Specific_Variant__c);
         Test.stopTest();
 
         //then

--- a/src/classes/PMHR_PokemonPictureController.cls
+++ b/src/classes/PMHR_PokemonPictureController.cls
@@ -7,7 +7,7 @@ public class PMHR_PokemonPictureController {
 
     private static Pokemon__c getPokemonData(Id pokemonId) {
         return [
-                SELECT Id, Variant__c,
+                SELECT Id, Region_Specific_Variant__c,
                         Form__r.Picture_Url__c, Form__r.Type__c,
                         Form__r.Alolan_Picture_Url__c, Form__r.Alolan_Type__c,
                         Form__r.Galarian_Picture_Url__c, Form__r.Galarian_Type__c
@@ -23,8 +23,8 @@ public class PMHR_PokemonPictureController {
 
         public PokemonPicture (Pokemon__c pokemon) {
             PMHR_PokemonPictureVariantsConfig config = PMHR_PokemonPictureVariantsConfig.getInstance();
-            this.pictureUrl = (String)pokemon.Form__r.get(config.getPictureFieldApiName(pokemon.Variant__c));
-            this.pokemonType = (String)pokemon.Form__r.get(config.getTypeFieldApiName(pokemon.Variant__c));
+            this.pictureUrl = (String)pokemon.Form__r.get(config.getPictureFieldApiName(pokemon.Region_Specific_Variant__c));
+            this.pokemonType = (String)pokemon.Form__r.get(config.getTypeFieldApiName(pokemon.Region_Specific_Variant__c));
         }
     }
 }

--- a/src/classes/PMHR_PokemonPictureVariantsConfig.cls
+++ b/src/classes/PMHR_PokemonPictureVariantsConfig.cls
@@ -3,13 +3,14 @@ public class PMHR_PokemonPictureVariantsConfig {
     private static Map<String, List<String>> regionVariantToFieldsApiNamesMap;
 
     private PMHR_PokemonPictureVariantsConfig() {
-        regionVariantToFieldsApiNamesMap = new Map<String, List<String>>();
         String pictureUrlFieldApiName = Pokemon_Data__c.Picture_Url__c.getDescribe().getName();
         String typeFieldApiName = Pokemon_Data__c.Type__c.getDescribe().getName();
+        regionVariantToFieldsApiNamesMap = new Map<String, List<String>>();
+        regionVariantToFieldsApiNamesMap.put(null, new List<String> {pictureUrlFieldApiName, typeFieldApiName});
         for (PicklistEntry variant : PMHR_Utilities.POKEMON_REGIONAL_VARIANT) {
             String variantName = variant.getValue();
-            String pictureApiName = variantName == PMHR_Utilities.REGION_VARIANT_STANDARD ? pictureUrlFieldApiName : String.join(new List<String>{variantName, pictureUrlFieldApiName}, '_');
-            String typeApiName = variantName == PMHR_Utilities.REGION_VARIANT_STANDARD ? typeFieldApiName : String.join(new List<String>{variantName, typeFieldApiName}, '_');
+            String pictureApiName = String.join(new List<String>{variantName, pictureUrlFieldApiName}, '_');
+            String typeApiName = String.join(new List<String>{variantName, typeFieldApiName}, '_');
             regionVariantToFieldsApiNamesMap.put(variantName, new List<String>{pictureApiName, typeApiName});
         }
     }

--- a/src/classes/PMHR_TestDataFactory.cls
+++ b/src/classes/PMHR_TestDataFactory.cls
@@ -42,9 +42,7 @@ public class PMHR_TestDataFactory {
         pokemonData.Family_Stage__c = familyStage;
         List<String> variants = new List<String>();
         for (PicklistEntry variant : PMHR_Utilities.POKEMON_REGIONAL_VARIANT) {
-            if (variant.getValue() != PMHR_Utilities.REGION_VARIANT_STANDARD) {
-                variants.add(variant.getValue());
-            }
+            variants.add(variant.getValue());
         }
         pokemonData.Region_Specific_Variants__c = String.join(variants, ';');
 
@@ -52,7 +50,7 @@ public class PMHR_TestDataFactory {
     }
 
     public static Pokemon__c createPokemonObject(String name, String gender, Id caughtFormId, String catchMethod, Id nuzlockeId) {
-        return createPokemonObject(name, gender, caughtFormId, null, catchMethod, nuzlockeId, PMHR_Utilities.REGION_VARIANT_STANDARD);
+        return createPokemonObject(name, gender, caughtFormId, null, catchMethod, nuzlockeId, null);
     }
 
     public static Pokemon__c createPokemonObject(String name, String gender, Id caughtFormId, Id formId, String catchMethod, Id nuzlockeId, String variant) {
@@ -63,7 +61,7 @@ public class PMHR_TestDataFactory {
         pokemon.Form__c = formId;
         pokemon.Catch_Method__c = catchMethod;
         pokemon.Nuzlocke__c = nuzlockeId;
-        pokemon.Variant__c = variant;
+        pokemon.Region_Specific_Variant__c = variant;
 
         return pokemon;
     }

--- a/src/classes/PMHR_TriggerHandlerPokemon_Test.cls
+++ b/src/classes/PMHR_TriggerHandlerPokemon_Test.cls
@@ -50,7 +50,7 @@ private class PMHR_TriggerHandlerPokemon_Test {
             }
         }
 
-        Pokemon__c newPokemon = PMHR_TestDataFactory.createPokemonObject('New', PMHR_Utilities.GENDER_MALE, firstStageForm.Id, secondStageForm.Id, PMHR_Utilities.POKEMON_CATCH_METHOD_EVENT, nuzlocke.Id, PMHR_Utilities.REGION_VARIANT_STANDARD);
+        Pokemon__c newPokemon = PMHR_TestDataFactory.createPokemonObject('New', PMHR_Utilities.GENDER_MALE, firstStageForm.Id, secondStageForm.Id, PMHR_Utilities.POKEMON_CATCH_METHOD_EVENT, nuzlocke.Id, null);
 
         //when
         Test.startTest();

--- a/src/classes/PMHR_Utilities.cls
+++ b/src/classes/PMHR_Utilities.cls
@@ -9,7 +9,5 @@ public class PMHR_Utilities {
 
     public static final String GENDER_MALE = 'Male';
 
-    public static final String REGION_VARIANT_STANDARD = 'Standard';
-
-    public static final List<PicklistEntry> POKEMON_REGIONAL_VARIANT = Pokemon__c.Variant__c.getDescribe().getPicklistValues();
+    public static final List<PicklistEntry> POKEMON_REGIONAL_VARIANT = Pokemon__c.Region_Specific_Variant__c.getDescribe().getPicklistValues();
 }

--- a/src/globalValueSets/Region_Specific_Pokemon_Variants.globalValueSet
+++ b/src/globalValueSets/Region_Specific_Pokemon_Variants.globalValueSet
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<GlobalValueSet xmlns="http://soap.sforce.com/2006/04/metadata">
+    <customValue>
+        <fullName>Alolan</fullName>
+        <default>false</default>
+        <label>Alolan</label>
+    </customValue>
+    <customValue>
+        <fullName>Galarian</fullName>
+        <default>false</default>
+        <label>Galarian</label>
+    </customValue>
+    <masterLabel>Region Specific Pokemon Variants</masterLabel>
+    <sorted>false</sorted>
+</GlobalValueSet>

--- a/src/layouts/Pokemon__c-Pokemon Layout.layout
+++ b/src/layouts/Pokemon__c-Pokemon Layout.layout
@@ -56,8 +56,8 @@
                 <emptySpace>true</emptySpace>
             </layoutItems>
             <layoutItems>
-                <behavior>Required</behavior>
-                <field>Variant__c</field>
+                <behavior>Edit</behavior>
+                <field>Region_Specific_Variant__c</field>
             </layoutItems>
         </layoutColumns>
         <style>TwoColumnsTopToBottom</style>

--- a/src/objects/Final_Team_Member__c.object
+++ b/src/objects/Final_Team_Member__c.object
@@ -286,7 +286,7 @@
     <fields>
         <fullName>Type__c</fullName>
         <externalId>false</externalId>
-        <formula>IF(ISPICKVAL(Pokemon__r.Variant__c, &apos;Alolan&apos;), Pokemon__r.Form__r.Alolan_Type__c, Pokemon__r.Form__r.Type__c)</formula>
+        <formula>IF(ISPICKVAL(Pokemon__r.Region_Specific_Variant__c, &apos;Alolan&apos;), Pokemon__r.Form__r.Alolan_Type__c, Pokemon__r.Form__r.Type__c)</formula>
         <label>Type</label>
         <required>false</required>
         <trackTrending>false</trackTrending>

--- a/src/objects/Pokemon_Data__c.object
+++ b/src/objects/Pokemon_Data__c.object
@@ -2437,19 +2437,7 @@
         <type>MultiselectPicklist</type>
         <valueSet>
             <restricted>true</restricted>
-            <valueSetDefinition>
-                <sorted>false</sorted>
-                <value>
-                    <fullName>Alolan</fullName>
-                    <default>false</default>
-                    <label>Alolan</label>
-                </value>
-                <value>
-                    <fullName>Galarian</fullName>
-                    <default>false</default>
-                    <label>Galarian</label>
-                </value>
-            </valueSetDefinition>
+            <valueSetName>Region_Specific_Pokemon_Variants</valueSetName>
         </valueSet>
         <visibleLines>3</visibleLines>
     </fields>

--- a/src/objects/Pokemon__c.object
+++ b/src/objects/Pokemon__c.object
@@ -337,6 +337,18 @@
         <writeRequiresMasterRead>false</writeRequiresMasterRead>
     </fields>
     <fields>
+        <fullName>Region_Specific_Variant__c</fullName>
+        <externalId>false</externalId>
+        <label>Region Specific Variant</label>
+        <required>false</required>
+        <trackTrending>false</trackTrending>
+        <type>Picklist</type>
+        <valueSet>
+            <restricted>true</restricted>
+            <valueSetName>Region_Specific_Pokemon_Variants</valueSetName>
+        </valueSet>
+    </fields>
+    <fields>
         <fullName>Trainer__c</fullName>
         <externalId>false</externalId>
         <formula>Nuzlocke__r.Hero__r.Name</formula>
@@ -346,35 +358,6 @@
         <trackTrending>false</trackTrending>
         <type>Text</type>
         <unique>false</unique>
-    </fields>
-    <fields>
-        <fullName>Variant__c</fullName>
-        <externalId>false</externalId>
-        <label>Variant</label>
-        <required>true</required>
-        <trackTrending>false</trackTrending>
-        <type>Picklist</type>
-        <valueSet>
-            <restricted>true</restricted>
-            <valueSetDefinition>
-                <sorted>false</sorted>
-                <value>
-                    <fullName>Standard</fullName>
-                    <default>true</default>
-                    <label>Standard</label>
-                </value>
-                <value>
-                    <fullName>Alolan</fullName>
-                    <default>false</default>
-                    <label>Alolan</label>
-                </value>
-                <value>
-                    <fullName>Galarian</fullName>
-                    <default>false</default>
-                    <label>Galarian</label>
-                </value>
-            </valueSetDefinition>
-        </valueSet>
     </fields>
     <label>Pokemon</label>
     <listViews>
@@ -462,10 +445,10 @@
         <fullName>Forbidden_Alolan_Form</fullName>
         <active>true</active>
         <errorConditionFormula>AND(
-				ISPICKVAL(Variant__c, &apos;Alolan&apos;),
+				ISPICKVAL(Region_Specific_Variant__c, &apos;Alolan&apos;),
 				NOT(INCLUDES(Form__r.Region_Specific_Variants__c, &apos;Alolan&apos;))
 )</errorConditionFormula>
-        <errorDisplayField>Variant__c</errorDisplayField>
+        <errorDisplayField>Region_Specific_Variant__c</errorDisplayField>
         <errorMessage>The Pokemon form doesn&apos;t have alolan variant</errorMessage>
     </validationRules>
     <validationRules>
@@ -473,10 +456,10 @@
         <active>true</active>
         <description>The Pokemon form doesn&apos;t have galarian variant</description>
         <errorConditionFormula>AND(
-    ISPICKVAL(Variant__c, &apos;Galarian&apos;),
+    ISPICKVAL(Region_Specific_Variant__c, &apos;Galarian&apos;),
     NOT(INCLUDES(Form__r.Region_Specific_Variants__c, &apos;Galarian&apos;))
 )</errorConditionFormula>
-        <errorDisplayField>Variant__c</errorDisplayField>
+        <errorDisplayField>Region_Specific_Variant__c</errorDisplayField>
         <errorMessage>The Pokemon form doesn&apos;t have galarian variant</errorMessage>
     </validationRules>
     <validationRules>


### PR DESCRIPTION
Both Pokemon__c.object and Pokemon_Data__c.object use the same global picklist for region specific variants so the values are always synced.